### PR TITLE
Fix Vite base path for GitHub Pages deployment

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,7 +4,9 @@ import react from '@vitejs/plugin-react';
 
 export default defineConfig(({ mode }) => {
     const env = loadEnv(mode, '.', '');
+    const base = mode === 'production' ? '/age-of-ware-re-make-/' : '/';
     return {
+      base,
       server: {
         port: 3000,
         host: '0.0.0.0',


### PR DESCRIPTION
## Summary
- set the Vite base path to `/age-of-ware-re-make-/` during production builds so static assets resolve correctly on GitHub Pages

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d1b02efb9c832f959715415eb9ebbe